### PR TITLE
Debug action publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,11 @@ jobs:
     
     steps:
     - uses: actions/checkout@v1
+    - name: Setup .npmrc file to publish to npm
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+        registry-url: 'https://registry.npmjs.org'
     - name: Install dependencies
       run: npm ci
     - name: Publish to npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qiniu/eslint-config",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qiniu/eslint-config",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "ESLint config for Qiniu",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
Do setup-node before `npm publish`.

See https://help.github.com/en/actions/language-and-framework-guides/publishing-nodejs-packages.