### PR TITLE
更新到 eslint 7.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,17 +16,17 @@
   "author": "nighca@live.cn",
   "license": "MIT",
   "dependencies": {
-    "@typescript-eslint/parser": "^4.5.0",
-    "eslint-config-airbnb": "^18.0.1"
+    "@typescript-eslint/parser": "~4.5.0",
+    "eslint-config-airbnb": "~18.2.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.5.0",
-    "eslint": "^6.5.1",
-    "eslint-import-resolver-typescript": "^2.2.0",
-    "eslint-plugin-import": "^2.19.1",
-    "eslint-plugin-jsx-a11y": "^6.2.3",
-    "eslint-plugin-react": "^7.17.0",
-    "eslint-plugin-react-hooks": "^1.7.0"
+    "@typescript-eslint/eslint-plugin": "~4.5.0",
+    "eslint": "~7.2.0",
+    "eslint-import-resolver-typescript": "~2.3.0",
+    "eslint-plugin-import": "~2.21.2",
+    "eslint-plugin-jsx-a11y": "~6.3.0",
+    "eslint-plugin-react": "~7.20.0",
+    "eslint-plugin-react-hooks": "~4.2.0"
   },
   "bugs": {
     "url": "https://github.com/qiniu/eslint-config/issues"


### PR DESCRIPTION
eslint6 主要对 optional chain 支持得不行

https://github.com/typescript-eslint/typescript-eslint/issues/1220

> no-unused-expressions will report error, @typescript-eslint/no-unused-expressions is work fine.


升级到 7 ok，目前没发现特别的改动，只需要升级依赖就行