### PR TITLE
升级 eslint-plugin-import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qiniu/eslint-config",
-  "version": "0.0.6-beta.4",
+  "version": "0.0.6-beta.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -156,22 +156,22 @@
       }
     },
     "eslint-config-airbnb": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.0.tgz",
-      "integrity": "sha512-Fz4JIUKkrhO0du2cg5opdyPKQXOI2MvF8KUvN2710nJMT6jaRUpRE2swrJftAjVGL7T1otLM5ieo5RqS1v9Udg==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz",
+      "integrity": "sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==",
       "requires": {
-        "eslint-config-airbnb-base": "^14.2.0",
-        "object.assign": "^4.1.0",
+        "eslint-config-airbnb-base": "^14.2.1",
+        "object.assign": "^4.1.2",
         "object.entries": "^1.1.2"
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.0.tgz",
-      "integrity": "sha512-Snswd5oC6nJaevs3nZoLSTvGJBvzTfnBqOIArkf3cbyTyq9UD79wOk8s+RiL6bhca0p/eRO6veczhf6A/7Jy8Q==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
+      "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
       "requires": {
-        "confusing-browser-globals": "^1.0.9",
-        "object.assign": "^4.1.0",
+        "confusing-browser-globals": "^1.0.10",
+        "object.assign": "^4.1.2",
         "object.entries": "^1.1.2"
       }
     },
@@ -286,11 +286,6 @@
         "is-extglob": "^2.1.1"
       }
     },
-    "is-negative-zero": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
-      "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE="
-    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -398,63 +393,21 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
     "string.prototype.trimend": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz",
-      "integrity": "sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+      "integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz",
-      "integrity": "sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+      "integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.1"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.18.0-next.1",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.2",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.1",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3"
       }
     },
     "to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qiniu/eslint-config",
-  "version": "0.0.6-beta.5",
+  "version": "0.0.6-beta.6",
   "description": "ESLint config for Qiniu",
   "main": "index.js",
   "scripts": {},
@@ -23,7 +23,7 @@
     "@typescript-eslint/eslint-plugin": "~4.5.0",
     "eslint": "~7.2.0",
     "eslint-import-resolver-typescript": "~2.3.0",
-    "eslint-plugin-import": "~2.21.2",
+    "eslint-plugin-import": "~2.22.1",
     "eslint-plugin-jsx-a11y": "~6.3.0",
     "eslint-plugin-react": "~7.20.0",
     "eslint-plugin-react-hooks": "~4.2.0"


### PR DESCRIPTION
eslint-config-airbnb@18.2.0(eslint-config-airbnb-base@14.2.0) -> 18.2.1(eslint-config-airbnb-base@14.2.1) 调整了 `import/no-cycle` 的配置（改动详情见 [Valid 'no-cycle' value](https://github.com/airbnb/javascript/pull/2250/files#diff-e5c4778bd676e5d1cefbad9b3f3932a485f069492c0937290cabf7c157dde21dR236)），不兼容当前版本的 eslint-plugin-import，会报错

```
Oops! Something went wrong! :(

ESLint: 7.2.0

Error: .eslintrc.js » @qiniu/eslint-config » eslint-config-airbnb-base » /Users/nighca/code/portal-base/node_modules/eslint-config-airbnb-base/rules/imports.js:
        Configuration for rule "import/no-cycle" is invalid:
        Value "∞" should be integer.

    at validateRuleOptions (/Users/nighca/code/portal-base/node_modules/eslint/lib/shared/config-validator.js:132:19)
    at /Users/nighca/code/portal-base/node_modules/eslint/lib/shared/config-validator.js:187:9
    at Array.forEach (<anonymous>)
    at validateRules (/Users/nighca/code/portal-base/node_modules/eslint/lib/shared/config-validator.js:184:30)
    at validateConfigArray (/Users/nighca/code/portal-base/node_modules/eslint/lib/shared/config-validator.js:312:9)
    at CascadingConfigArrayFactory._finalizeConfigArray (/Users/nighca/code/portal-base/node_modules/eslint/lib/cli-engine/cascading-config-array-factory.js:464:13)
    at CascadingConfigArrayFactory.getConfigArrayForFile (/Users/nighca/code/portal-base/node_modules/eslint/lib/cli-engine/cascading-config-array-factory.js:275:21)
    at FileEnumerator._iterateFilesWithFile (/Users/nighca/code/portal-base/node_modules/eslint/lib/cli-engine/file-enumerator.js:356:43)
    at FileEnumerator._iterateFiles (/Users/nighca/code/portal-base/node_modules/eslint/lib/cli-engine/file-enumerator.js:337:25)
    at FileEnumerator.iterateFiles (/Users/nighca/code/portal-base/node_modules/eslint/lib/cli-engine/file-enumerator.js:287:59)
```